### PR TITLE
fix the tx verify failed

### DIFF
--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -208,11 +208,6 @@ export default class Transaction {
             newtx.contractRequests = newtx.contractRequests.map((req: any) => {
                 if (req.args) {
                     req.args = JSON.parse(stringify(req.args));
-                    Object.keys(req.args).map((key: string) => {
-                        if (req.args[key] === "") {
-                            req.args[key] = null
-                        }
-                    });
                 }
                 return req;
             });


### PR DESCRIPTION
## Description

What is the purpose of the change?

修复在 xuperchain v5.3 版本下，转账交易，合约调用 **value=""** 交易时交易ID验证失败问题。

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Brief of your solution

不再强制将 **value=""** 的参数强制转换为 **value=null**

## How Has This Been Tested?

在 xuperchain v5.3 版本下，搭配背书环境时，当 contractRequest的 args 存在 value = "" 情况时，可以复现此问题。
